### PR TITLE
Add `detectIndent` option to detect indentation automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,7 @@ const init = (fn, fp, data, opts) => {
 	return fn(fp, data, opts);
 };
 
-const readFile = fp => {
-	return pify(fs.readFile)(fp, 'utf8')
-		.catch(() => {});
-};
+const readFile = fp => pify(fs.readFile)(fp, 'utf8').catch(() => {});
 
 const main = (fp, data, opts) => {
 	return (opts.detectIndent ? readFile(fp) : Promise.resolve())

--- a/index.js
+++ b/index.js
@@ -33,13 +33,7 @@ const init = (fn, fp, data, opts) => {
 
 const readFile = fp => {
 	return pify(fs.readFile)(fp, 'utf8')
-		.catch(err => {
-			if (err.code === 'ENOENT') {
-				return null;
-			}
-
-			throw err;
-		});
+		.catch(() => {});
 };
 
 const main = (fp, data, opts) => {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     "atomically"
   ],
   "dependencies": {
+    "detect-indent": "^5.0.0",
     "graceful-fs": "^4.1.2",
     "make-dir": "^1.0.0",
+    "path-exists": "^3.0.0",
     "pify": "^2.0.0",
     "sort-keys": "^1.1.1",
     "write-file-atomic": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "detect-indent": "^5.0.0",
     "graceful-fs": "^4.1.2",
     "make-dir": "^1.0.0",
-    "path-exists": "^3.0.0",
     "pify": "^2.0.0",
     "sort-keys": "^1.1.1",
     "write-file-atomic": "^2.0.0"

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Default: `\t`
 Indentation as a string or number of spaces.<br>
 Pass in `null` for no formatting.
 
-##### auto
+##### detectIndent
 
 Type: `boolean`<br>
 Default: `false`

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,13 @@ Default: `\t`
 Indentation as a string or number of spaces.<br>
 Pass in `null` for no formatting.
 
+##### auto
+
+Type: `boolean`<br>
+Default: `false`
+
+Detect indentation automatically if the file exists.
+
 ##### sortKeys
 
 Type: `boolean` `function`<br>

--- a/test.js
+++ b/test.js
@@ -12,19 +12,26 @@ test('async', async t => {
 
 test('sync', t => {
 	const tmp = path.join(tempfile(), 'foo');
-	m.sync(tmp, {foo: true}, {indent: 2});
+	m.sync(tmp, {foo: true}, {detectIndent: true, indent: 2});
 	t.is(fs.readFileSync(tmp, 'utf8'), '{\n  "foo": true\n}\n');
 });
 
 test('detect indent', async t => {
 	const tmp = path.join(tempfile(), 'foo');
 	await m(tmp, {foo: true}, {indent: 2});
-	await m(tmp, {foo: true, bar: true, foobar: true}, {auto: true});
+	await m(tmp, {foo: true, bar: true, foobar: true}, {detectIndent: true});
+	t.is(fs.readFileSync(tmp, 'utf8'), '{\n  "foo": true,\n  "bar": true,\n  "foobar": true\n}\n');
+});
+
+test('detect indent synchronously', t => {
+	const tmp = path.join(tempfile(), 'foo');
+	m.sync(tmp, {foo: true}, {indent: 2});
+	m.sync(tmp, {foo: true, bar: true, foobar: true}, {detectIndent: true});
 	t.is(fs.readFileSync(tmp, 'utf8'), '{\n  "foo": true,\n  "bar": true,\n  "foobar": true\n}\n');
 });
 
 test('fall back to default indent if file doesn\'t exist', async t => {
 	const tmp = path.join(tempfile(), 'foo');
-	await m(tmp, {foo: true, bar: true, foobar: true}, {auto: true});
+	await m(tmp, {foo: true, bar: true, foobar: true}, {detectIndent: true});
 	t.is(fs.readFileSync(tmp, 'utf8'), '{\n\t"foo": true,\n\t"bar": true,\n\t"foobar": true\n}\n');
 });

--- a/test.js
+++ b/test.js
@@ -15,3 +15,16 @@ test('sync', t => {
 	m.sync(tmp, {foo: true}, {indent: 2});
 	t.is(fs.readFileSync(tmp, 'utf8'), '{\n  "foo": true\n}\n');
 });
+
+test('detect indent', async t => {
+	const tmp = path.join(tempfile(), 'foo');
+	await m(tmp, {foo: true}, {indent: 2});
+	await m(tmp, {foo: true, bar: true, foobar: true}, {auto: true});
+	t.is(fs.readFileSync(tmp, 'utf8'), '{\n  "foo": true,\n  "bar": true,\n  "foobar": true\n}\n');
+});
+
+test('fall back to default indent if file doesn\'t exist', async t => {
+	const tmp = path.join(tempfile(), 'foo');
+	await m(tmp, {foo: true, bar: true, foobar: true}, {auto: true});
+	t.is(fs.readFileSync(tmp, 'utf8'), '{\n\t"foo": true,\n\t"bar": true,\n\t"foobar": true\n}\n');
+});


### PR DESCRIPTION
Thought about using `opts.indent === true` instead of the `auto` option, but then we would need to handle cases where `indent === true` but the file doesn't exists. Also, `auto` is probably more understandable anyway.