### PR TITLE
Explicitly disable chown for file writes

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const main = async (filePath, data, options) => {
 
 	const json = JSON.stringify(data, options.replacer, indent);
 
-	return writeFileAtomic(filePath, `${json}${trailingNewline}`, {mode: options.mode, chown:false});
+	return writeFileAtomic(filePath, `${json}${trailingNewline}`, {mode: options.mode, chown: false});
 };
 
 const mainSync = (filePath, data, options) => {
@@ -80,7 +80,7 @@ const mainSync = (filePath, data, options) => {
 
 	const json = JSON.stringify(data, options.replacer, indent);
 
-	return writeFileAtomic.sync(filePath, `${json}${trailingNewline}`, {mode: options.mode, chown:false});
+	return writeFileAtomic.sync(filePath, `${json}${trailingNewline}`, {mode: options.mode, chown: false});
 };
 
 module.exports = async (filePath, data, options) => {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const main = async (filePath, data, options) => {
 
 	const json = JSON.stringify(data, options.replacer, indent);
 
-	return writeFileAtomic(filePath, `${json}${trailingNewline}`, {mode: options.mode});
+	return writeFileAtomic(filePath, `${json}${trailingNewline}`, {mode: options.mode, chown:false});
 };
 
 const mainSync = (filePath, data, options) => {
@@ -80,7 +80,7 @@ const mainSync = (filePath, data, options) => {
 
 	const json = JSON.stringify(data, options.replacer, indent);
 
-	return writeFileAtomic.sync(filePath, `${json}${trailingNewline}`, {mode: options.mode});
+	return writeFileAtomic.sync(filePath, `${json}${trailingNewline}`, {mode: options.mode, chown:false});
 };
 
 module.exports = async (filePath, data, options) => {


### PR DESCRIPTION
Due to a bug in write-file-atomic saving to a permissionless filesystem ( eg fat32, exfat ) in linux without explicitly setting chown to false, causes the write to fail. As noted here: https://github.com/npm/write-file-atomic/issues/58

By simply setting chown argument explicitly, this error will not occur.